### PR TITLE
Do not convert non-addition ancestor

### DIFF
--- a/ts-simple-ast-extra/spec/refactors/stringConcatenationToTemplateSpec.ts
+++ b/ts-simple-ast-extra/spec/refactors/stringConcatenationToTemplateSpec.ts
@@ -39,6 +39,9 @@ describe('stringConcatenationToTemplate', () => {
         function g(a: number) {
           return a + 2
         } 
+        const text1 = 'ba'
+        const text2 = 'ar'
+        const isTheSame = text1 + 'r' === 'b' + text2
       `
       )!
       stringConcatenationsToTemplateExpressions(f, project.getTypeChecker())
@@ -53,6 +56,9 @@ describe('stringConcatenationToTemplate', () => {
         function g(a: number) {
           return a + 2
         }
+        const text1 = 'ba'
+        const text2 = 'ar'
+        const isTheSame = \`\${text1}r\` === \`b\${text2}\`
       `)
       )
     })

--- a/ts-simple-ast-extra/src/refactor/impl/stringConcatenationToTemplate.ts
+++ b/ts-simple-ast-extra/src/refactor/impl/stringConcatenationToTemplate.ts
@@ -44,7 +44,7 @@ function stringConcatenation2TemplateExpressionRecursively(exprBase: BinaryExpre
   exprBuffer = []
   let expr: Node | undefined = exprBase
   stringConcatenation2TemplateExpression(exprBase, tc, true)
-  while ((expr = expr.getParent()) && TypeGuards.isBinaryExpression(expr)) {
+  while ((expr = expr.getParent()) && stringConcatenationNodePredicate(expr, tc)) {
     stringConcatenation2TemplateExpression(expr, tc)
   }
   const text = `\`${exprBuffer.join('')}\``


### PR DESCRIPTION
Given:
let text1 = 'ba';
let text2 = 'ar';
let isTheSame = text1 + 'r' === 'b' + text2;

When:
Refactoring enabling "String concatenation to template expression"...

Actual:
let text1 = 'ba';
let text2 = 'ar';
let isTheSame = `${text1}r${`b${text2}`}`;

Expected:
let text1 = 'ba';
let text2 = 'ar';
let isTheSame = `${text1}r` === `b${text2}`;

Operand types and operator should be checked.